### PR TITLE
Redirect the user to their previous page after log in and registration

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -43,7 +43,7 @@ class LoginController extends Controller
 
     public function redirectToProvider()
     {
-        session()->flash('redirect_url', url()->previous());
+        session()->flash('url.intended', url()->previous());
 
         return Socialite::driver('github')->redirect();
     }
@@ -58,11 +58,7 @@ class LoginController extends Controller
 
         Auth::login($user, false);
 
-        if (session()->get('redirect_url')) {
-            return redirect(session()->get('redirect_url'));
-        }
-
-        return redirect()->route('home');
+        return redirect()->intended();
     }
 
     private function createOrUpdateUser($socialiteUser)

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -43,6 +43,8 @@ class LoginController extends Controller
 
     public function redirectToProvider()
     {
+        session()->flash('redirect_url', url()->previous());
+
         return Socialite::driver('github')->redirect();
     }
 
@@ -55,6 +57,10 @@ class LoginController extends Controller
         }
 
         Auth::login($user, false);
+
+        if (session()->get('redirect_url')) {
+            return redirect(session()->get('redirect_url'));
+        }
 
         return redirect()->route('home');
     }

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -18,7 +18,7 @@ class RedirectIfAuthenticated
     public function handle($request, Closure $next, $guard = null)
     {
         if (Auth::guard($guard)->check()) {
-            return redirect('/app/home');
+            return redirect()->route('home');
         }
 
         return $next($request);


### PR DESCRIPTION
This PR stores the url that the user was at before they hit the `Log in / Register` link and redirects them back to that page after successful log in or registration.

Fixes #3 