### PR TITLE
Update test suite

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -33,5 +33,6 @@
         <env name="DB_CONNECTION" value="sqlite"/>
         <env name="DB_DATABASE" value=":memory:"/>
         <env name="SCOUT_DRIVER" value="null"/>
+        <env name="TELESCOPE_ENABLED" value="false"/>
     </php>
 </phpunit>

--- a/tests/Unit/Http/Resources/PackageDetailResourceTest.php
+++ b/tests/Unit/Http/Resources/PackageDetailResourceTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Unit\Http\Resources;
+
+use App\Http\Resources\PackageDetailResource;
+use App\Package;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PackageDetailResourceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function can_determine_if_the_package_is_favorited_by_the_authenticated_user()
+    {
+        $package = factory(Package::class)->create();
+        $user = factory(User::class)->create();
+        $user->favoritePackage($package->id);
+
+        $this->actingAs($user);
+        $packageDetailResource = (PackageDetailResource::from($package));
+
+        $this->assertTrue($packageDetailResource['is_favorite'], 'Failed asserting the package is favorited');
+    }
+
+    /** @test */
+    public function can_determine_if_the_package_is_unfavorited_by_the_authenticated_user()
+    {
+        $package = factory(Package::class)->create();
+        $user = factory(User::class)->create();
+
+        $this->actingAs($user);
+        $packageDetailResource = (PackageDetailResource::from($package));
+
+        $this->assertFalse($packageDetailResource['is_favorite'], 'Failed asserting the package is unfavorited');
+    }
+
+    /** @test */
+    public function return_the_count_of_favorites_for_a_package()
+    {
+        $package = factory(Package::class)->create();
+        $userA = factory(User::class)->create();
+        $userA->favoritePackage($package->id);
+        $userB = factory(User::class)->create();
+        $userB->favoritePackage($package->id);
+
+        $packageDetailResource = (PackageDetailResource::from($package));
+
+        $this->assertEquals(2, $packageDetailResource['favorites_count']);
+    }
+}

--- a/tests/Unit/Http/Resources/PackageResourceTest.php
+++ b/tests/Unit/Http/Resources/PackageResourceTest.php
@@ -39,43 +39,4 @@ class PackageResourceTest extends TestCase
         $this->assertNotNull($packageResource['abstract']);
         $this->assertEquals($packageResource['abstract'], $package->abstract);
     }
-
-    /** @test */
-    public function can_determine_if_the_package_is_favorited_by_the_authenticated_user()
-    {
-        $package = factory(Package::class)->create();
-        $user = factory(User::class)->create();
-        $user->favoritePackage($package->id);
-
-        $this->actingAs($user);
-        $packageResource = (PackageResource::from($package));
-
-        $this->assertTrue($packageResource['is_favorite'], 'Failed asserting the package is favorited');
-    }
-
-    /** @test */
-    public function can_determine_if_the_package_is_unfavorited_by_the_authenticated_user()
-    {
-        $package = factory(Package::class)->create();
-        $user = factory(User::class)->create();
-
-        $this->actingAs($user);
-        $packageResource = (PackageResource::from($package));
-
-        $this->assertFalse($packageResource['is_favorite'], 'Failed asserting the package is unfavorited');
-    }
-
-    /** @test */
-    public function return_the_count_of_favorites_for_a_package()
-    {
-        $package = factory(Package::class)->create();
-        $userA = factory(User::class)->create();
-        $userA->favoritePackage($package->id);
-        $userB = factory(User::class)->create();
-        $userB->favoritePackage($package->id);
-
-        $packageResource = (PackageResource::from($package));
-
-        $this->assertEquals(2, $packageResource['favorites_count']);
-    }
 }


### PR DESCRIPTION
This PR fixes a couple issues with the test suite. 

First, it disables Laravel Telescope during tests. Having Telescope enabled during tests seems to "eat" any exceptions that are thrown during the test and displays `Illuminate\Contracts\Container\BindingResolutionException: Target class [env] does not exist.` for every error:
![image](https://user-images.githubusercontent.com/1141514/73685714-7d941580-467b-11ea-9f01-dbff51a5282d.png)

Second, some attributes that belonged to `PackageResource` were moved to `PackageDetailResource` without the tests being updated. This PR creates `PackageDetailResourceTest` and simply moves the relevant tests to it.