### PR TITLE
Clearing small todos

### DIFF
--- a/app/Http/Controllers/App/PackageController.php
+++ b/app/Http/Controllers/App/PackageController.php
@@ -94,9 +94,6 @@ class PackageController extends Controller
         $package->tags()->sync(array_merge($request->input('tags', []), $newTagsCreated));
         $package->syncScreenshots($request->input('screenshots', []));
 
-        // @todo: create this event
-        // event(new PackageUpdated($package));
-
         return redirect()->route('app.packages.index');
     }
 

--- a/database/migrations/2018_07_27_161503_create_tools_table.php
+++ b/database/migrations/2018_07_27_161503_create_tools_table.php
@@ -10,7 +10,7 @@ class CreateToolsTable extends Migration
     {
         Schema::create('tools', function (Blueprint $table) {
             $table->increments('id');
-            $table->unsignedInteger('author_id'); // @todo add fk constraint
+            $table->unsignedInteger('author_id');
             $table->string('name');
             $table->string('type');
             $table->string('promo_url');

--- a/database/migrations/2018_07_27_161749_create_authors_table.php
+++ b/database/migrations/2018_07_27_161749_create_authors_table.php
@@ -13,7 +13,6 @@ class CreateAuthorsTable extends Migration
             $table->string('name');
             $table->string('url');
             $table->text('description');
-            // @todo handle companies with multiple collaborators?
             $table->timestamps();
         });
     }

--- a/database/migrations/2020_02_03_202003_add_foreign_key_to_packages_table.php
+++ b/database/migrations/2020_02_03_202003_add_foreign_key_to_packages_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddForeignKeyToPackagesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('packages', function (Blueprint $table) {
+            $table->foreign('author_id')->references('id')->on('collaborators');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('packages', function (Blueprint $table) {
+            $table->dropForeign('packages_author_id_foreign');
+        });
+    }
+}


### PR DESCRIPTION
This PR clears a few small `todos` in the codebase. 

The only real change is adding a foreign key to the `packages` table for the `author_id`. The change works fine locally but it might cause problems in production if the database is in a bad state and has values in the `packages.author_id` column that do not exist in `collaborators.id`. It's probably a good idea to check that isn't the case before merging and deploying.