### PR TITLE
Update the output for deleting ratings to distinguish self-contributed

### DIFF
--- a/app/Console/Commands/DeleteSelfAuthoredPackageRatings.php
+++ b/app/Console/Commands/DeleteSelfAuthoredPackageRatings.php
@@ -37,7 +37,7 @@ class DeleteSelfAuthoredPackageRatings extends Command
                 ->whereRaw('collaborators.user_id = ratings.user_id');
         });
 
-        $this->info("Deleting {$query->count()} self-authored package ratings");
+        $this->info("Deleting {$query->count()} self-contributed package ratings");
 
         $query->delete();
     }


### PR DESCRIPTION
This PR adds clarity in the output of `purge:self-authored-package-ratings` command in order to distinguish the number of deleted `self-authored` ratings from the number of `self-contributed` ratings.

## Before
![image](https://user-images.githubusercontent.com/1121383/73760149-957aa080-4732-11ea-9764-44e4f6559c75.png)

## After
![image](https://user-images.githubusercontent.com/1121383/73760159-9ad7eb00-4732-11ea-92ee-4048762e042b.png)
