### PR TITLE
Update GitHub authentication to avoid deprecated method

### DIFF
--- a/app/Providers/GitHubServiceProvider.php
+++ b/app/Providers/GitHubServiceProvider.php
@@ -12,7 +12,7 @@ class GitHubServiceProvider extends ServiceProvider
     {
         $this->app->bind(GitHubClient::class, function ($app) {
             $client = new GitHubClient(null, 'squirrel-girl-preview');
-            $client->authenticate(config('services.github.client_id'), GitHubClient::AUTH_HTTP_PASSWORD);
+            $client->authenticate(config('services.github.client_id'), config('services.github.client_secret'), GitHubClient::AUTH_HTTP_PASSWORD);
 
             return $client;
         });

--- a/app/Providers/GitHubServiceProvider.php
+++ b/app/Providers/GitHubServiceProvider.php
@@ -12,7 +12,7 @@ class GitHubServiceProvider extends ServiceProvider
     {
         $this->app->bind(GitHubClient::class, function ($app) {
             $client = new GitHubClient(null, 'squirrel-girl-preview');
-            $client->authenticate(config('services.github.client_id'), config('services.github.client_secret'), GitHubClient::AUTH_URL_CLIENT_ID);
+            $client->authenticate(config('services.github.client_id'), GitHubClient::AUTH_HTTP_PASSWORD);
 
             return $client;
         });


### PR DESCRIPTION
We received an email from GitHub saying to use Basic Authentication instead of `client_id` and `client_secret` via query parameters as using OAuth credentials in query parameters has been [deprecated](https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#authenticating-using-query-parameters).

`AUTH_HTTP_PASSWORD` seems oddly named, to me, but actually [does what we want](https://github.com/KnpLabs/php-github-api/blob/d404193c0c1772e3e5b101b49633ad1d9b4ab1e1/lib/Github/HttpClient/Plugin/Authentication.php#L36-L41).