### PR TITLE
Query the correct relationship when checking authors

### DIFF
--- a/app/Jobs/UserRatePackage.php
+++ b/app/Jobs/UserRatePackage.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use App\Collaborator;
 use App\Exceptions\SelfAuthoredRatingException;
 use App\Package;
 use Illuminate\Bus\Queueable;
@@ -60,7 +61,7 @@ class UserRatePackage implements ShouldQueue
 
     private function isSelfAuthored($package)
     {
-        return (int) $package->author_id === (int) $this->userId;
+        return (int) $package->author_id === (int) optional(Collaborator::where('user_id', $this->userId)->first())->id;
     }
 
     private function isSelfContributed($package)

--- a/tests/Feature/InternalApi/InternalApiRatingsTest.php
+++ b/tests/Feature/InternalApi/InternalApiRatingsTest.php
@@ -81,7 +81,11 @@ class InternalApiRatingsTest extends TestCase
     function a_user_cannot_rate_a_package_they_authored()
     {
         $user = factory(User::class)->create();
-        $package = factory(Package::class)->create(['author_id' => $user->id]);
+        $package = factory(Package::class)->create([
+            'author_id' => factory(Collaborator::class)->create([
+                'user_id' => $user->id,
+            ]),
+        ]);
 
         $request = $this->be($user)->post(route('internalapi.ratings.store'), [
             'package_id' => $package->id,


### PR DESCRIPTION
This PR updates a check to use the correct key. Previously it was checking `package.author_id` against `user.id` when it should really check the `collaborators.user_id`.

It also updates a broken test.

---

**Important:** The `purge:self-authored-package-ratings` should be re-run in order to delete any self-authored package ratings that weren't included in the first run.