### PR TITLE
Redirect /package/{id} to /package/{namespace}/{name}

### DIFF
--- a/app/Http/Controllers/PackageController.php
+++ b/app/Http/Controllers/PackageController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers;
 
 use App\Package;
-use Illuminate\Support\Str;
 use App\Http\Resources\PackageDetailResource;
 
 class PackageController extends Controller
@@ -31,8 +30,8 @@ class PackageController extends Controller
     public function showId(Package $package)
     {
         return redirect()->route('packages.show', [
-            'namespace' => Str::before($package->composer_name, '/'),
-            'name' => Str::after($package->composer_name, '/'),
+            'namespace' => $package->composer_vendor,
+            'name' => $package->composer_package,
         ]);
     }
 }

--- a/app/Http/Controllers/PackageController.php
+++ b/app/Http/Controllers/PackageController.php
@@ -2,8 +2,9 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Resources\PackageDetailResource;
 use App\Package;
+use Illuminate\Support\Str;
+use App\Http\Resources\PackageDetailResource;
 
 class PackageController extends Controller
 {
@@ -12,8 +13,13 @@ class PackageController extends Controller
         return view('packages.index');
     }
 
-    public function show($namespace, $name)
+    public function show($namespace, $name = null)
     {
+        // Legacy URI by ID Support
+        if (is_numeric($namespace) && $name === null) {
+            return $this->idSearch($namespace);
+        }
+
         $query = Package::where('composer_name', $namespace.'/'.$name);
 
         if (auth()->user() && auth()->user()->isAdmin()) {
@@ -25,5 +31,15 @@ class PackageController extends Controller
         return view('packages.show')
             ->with('package', PackageDetailResource::from($package))
             ->with('screenshots', $package->screenshots);
+    }
+
+    public function idSearch($id)
+    {
+        $package = Package::findOrFail($id);
+
+        return redirect()->route('packages.show', [
+            'namespace' => Str::before($package->composer_name, '/'),
+            'name' => Str::after($package->composer_name, '/'),
+        ]);
     }
 }

--- a/app/Http/Controllers/PackageController.php
+++ b/app/Http/Controllers/PackageController.php
@@ -13,13 +13,8 @@ class PackageController extends Controller
         return view('packages.index');
     }
 
-    public function show($namespace, $name = null)
+    public function show($namespace, $name)
     {
-        // Legacy URI by ID Support
-        if (is_numeric($namespace) && $name === null) {
-            return $this->idSearch($namespace);
-        }
-
         $query = Package::where('composer_name', $namespace.'/'.$name);
 
         if (auth()->user() && auth()->user()->isAdmin()) {
@@ -33,10 +28,8 @@ class PackageController extends Controller
             ->with('screenshots', $package->screenshots);
     }
 
-    public function idSearch($id)
+    public function showId(Package $package)
     {
-        $package = Package::findOrFail($id);
-
         return redirect()->route('packages.show', [
             'namespace' => Str::before($package->composer_name, '/'),
             'name' => Str::after($package->composer_name, '/'),

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,7 +3,7 @@
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', 'PackageController@index')->name('home');
-Route::get('packages/{namespace}/{name}', 'PackageController@show')->name('packages.show');
+Route::get('packages/{namespace}/{name?}', 'PackageController@show')->name('packages.show');
 
 Route::group(['middleware' => 'auth'], function () {
     Route::get('packages/{namespace}/{name}/reviews/create', 'PackageReviewController@create')->name('reviews.create');

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,7 +3,8 @@
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', 'PackageController@index')->name('home');
-Route::get('packages/{namespace}/{name?}', 'PackageController@show')->name('packages.show');
+Route::get('packages/{namespace}/{name}', 'PackageController@show')->name('packages.show');
+Route::get('packages/{package}', 'PackageController@showId')->name('packages.show-id');
 
 Route::group(['middleware' => 'auth'], function () {
     Route::get('packages/{namespace}/{name}/reviews/create', 'PackageReviewController@create')->name('reviews.create');

--- a/tests/Feature/PackageViewTest.php
+++ b/tests/Feature/PackageViewTest.php
@@ -43,16 +43,16 @@ class PackageViewTest extends TestCase
     {
         $packageNamespace = 'tightenco';
         $packageName = 'bae';
-        $packageA = factory(Package::class)->make([
+        $package = factory(Package::class)->make([
             'composer_name' => "{$packageNamespace}/{$packageName}",
         ]);
         $collaborator = factory(Collaborator::class)->make();
         $user = factory(User::class)->create();
         $user->collaborators()->save($collaborator);
-        $collaborator->authoredPackages()->save($packageA);
+        $collaborator->authoredPackages()->save($package);
 
         $response = $this->actingAs($user)
-            ->get(route('packages.show', ['namespace' => $packageA->id]));
+            ->get(route('packages.show-id', ['package' => $package->id]));
 
         $response->assertRedirect(route('packages.show', ['namespace' => $packageNamespace, 'name' => $packageName]));
     }

--- a/tests/Feature/PackageViewTest.php
+++ b/tests/Feature/PackageViewTest.php
@@ -37,4 +37,23 @@ class PackageViewTest extends TestCase
         $response->assertViewHas('package');
         $response->assertViewHas('screenshots');
     }
+
+    /** @test */
+    public function legacy_package_id_lookup_redirects_to_namespace_search()
+    {
+        $packageNamespace = 'tightenco';
+        $packageName = 'bae';
+        $packageA = factory(Package::class)->make([
+            'composer_name' => "{$packageNamespace}/{$packageName}",
+        ]);
+        $collaborator = factory(Collaborator::class)->make();
+        $user = factory(User::class)->create();
+        $user->collaborators()->save($collaborator);
+        $collaborator->authoredPackages()->save($packageA);
+
+        $response = $this->actingAs($user)
+            ->get(route('packages.show', ['namespace' => $packageA->id]));
+
+        $response->assertRedirect(route('packages.show', ['namespace' => $packageNamespace, 'name' => $packageName]));
+    }
 }


### PR DESCRIPTION
This PR will redirect `https://novapackages.com/packages/{id}` to
`https://novapackages.com/packages/{namespace}/{name}`

Since the update from package IDs to their associated namespace and name, it broke linked package URLs on blogs, lists, and other resources.

Example:
https://github.com/its-awesome/awesome-laravel-nova (There you see `/package/{id}` links) 