### PR TITLE
Allow tags to be indexed via Scout

### DIFF
--- a/app/Http/Controllers/App/PackageController.php
+++ b/app/Http/Controllers/App/PackageController.php
@@ -35,8 +35,8 @@ class PackageController extends Controller
     {
         $repo = Repo::fromRequest($request);
 
-        // We disable syncing here and manually call ->searchable() after so
-        // the tags are stored in the database and can be indexed.
+        // We disable syncing here and manually call ->searchable() after the tag
+        // associations are established in the database so they can be indexed.
         $package = Package::withoutSyncingToSearch(function () use ($request, $repo) {
             // @todo: Kick off a sync operation and validate it's a real repo? grab name? geez there's a lot here that's sillly to make them enter manually
             $package = Package::create(array_merge(
@@ -85,6 +85,8 @@ class PackageController extends Controller
     {
         $repo = Repo::fromRequest($request);
 
+        // We disable syncing here and manually call ->searchable() after the tag
+        // associations are established in the database so they can be indexed.
         $package = Package::withoutSyncingToSearch(function () use ($package, $request, $repo) {
             $package->update(array_merge(
                 request()->only(['name', 'author_id', 'url', 'abstract', 'instructions']),


### PR DESCRIPTION
This PR delays the syncing of packages when created and updated until after the package's tags have been associated in the database.

Currently, tags are not being indexed via Scout because calling `Package::create` or `update` hits Scout's event listeners and indexes the data before the tag associations have been established.