### PR TITLE
Purge self-authored package ratings

### DIFF
--- a/app/Console/Commands/DeleteSelfAuthoredPackageRatings.php
+++ b/app/Console/Commands/DeleteSelfAuthoredPackageRatings.php
@@ -20,7 +20,9 @@ class DeleteSelfAuthoredPackageRatings extends Command
     private function deleteSelfAuthoredPackageRatings()
     {
         $query = Rating::whereHasMorph('rateable', 'App\Package', function ($query) {
-            return $query->whereRaw('packages.author_id = ratings.user_id');
+            return $query
+                ->join('collaborators', 'collaborators.id', '=', 'packages.author_id')
+                ->whereRaw('collaborators.user_id = ratings.user_id');
         });
 
         $this->info("Deleting {$query->count()} self-authored package ratings");

--- a/tests/Feature/DeleteSelfAuthoredPackageRatingsTest.php
+++ b/tests/Feature/DeleteSelfAuthoredPackageRatingsTest.php
@@ -17,7 +17,7 @@ class DeleteSelfAuthoredPackageRatingsTest extends TestCase
     function deleting_self_authored_package_ratings()
     {
         $packageAuthor = factory(User::class)->create();
-        // We are creating two collaborators here and setting the the
+        // We are creating two collaborators here and setting the
         // second one on the author to ensure the user_id on the rating
         // is different from the author_id on the package.
         $collaborators = factory(Collaborator::class, 2)->create();

--- a/tests/Feature/DeleteSelfAuthoredPackageRatingsTest.php
+++ b/tests/Feature/DeleteSelfAuthoredPackageRatingsTest.php
@@ -17,9 +17,14 @@ class DeleteSelfAuthoredPackageRatingsTest extends TestCase
     function deleting_self_authored_package_ratings()
     {
         $packageAuthor = factory(User::class)->create();
+        // We are creating two collaborators here and setting the the
+        // second one on the author to ensure the user_id on the rating
+        // is different from the author_id on the package.
+        $collaborators = factory(Collaborator::class, 2)->create();
+        $packageAuthor->collaborators()->save($collaborators->last());
         $otherUser = factory(User::class)->create();
         $package = factory(Package::class)->create([
-            'author_id' => $packageAuthor->id,
+            'author_id' => $collaborators->last()->id,
         ]);
 
         $invalidRating = new Rating(['rating' => 5]);


### PR DESCRIPTION
This PR is a follow-up to #28 that fixed a bug where a package was considered self-authored when the package's `author_id` was equal to the authenticated user's `id` when it should have been equal to one of the authenticated user's collaborators' `id`.

This PR updates the `purge:self-authored-package-ratings` command to query ratings based on this same logic.  Up to this point the `purge:self-authored-package-ratings` has not deleted any self-authored package ratings.

The below query is generated from the `purge:self-authored-package-ratings` command and at the time of this PR, running it on production selects `149` results.

```sql
select * from ratings
where (
	(rateable_type = 'App\\Package' 
	and exists (
		select * from packages
		inner join collaborators on collaborators.id = packages.author_id
		where ratings.rateable_id = packages.id 
		and collaborators.user_id = ratings.user_id 
		and is_disabled = 0
	))
)
```