### PR TITLE
Update collaborator GitHub username

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -79,6 +79,7 @@ class LoginController extends Controller
             'email' => $socialiteUser->getEmail(),
             'avatar' => $socialiteUser->getAvatar(),
             'github_username' => $socialiteUser->getNickname(),
+            'github_user_id' => $socialiteUser->getId(),
         ];
     }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -138,10 +138,11 @@ class User extends Authenticatable
 
     public function updateCollaboratorGithubUsernames()
     {
+        if (! $this->github_user_id) {
+            return;
+        }
+
         $this->collaborators
-            ->reject(function ($collaborator) {
-                return ! $collaborator->github_user_id;
-            })
             ->filter(function ($collaborator) {
                 return (int) $collaborator->github_user_id === (int) $this->github_user_id;
             })

--- a/app/User.php
+++ b/app/User.php
@@ -56,6 +56,9 @@ class User extends Authenticatable
             if ($user->isDirty('github_username')) {
                 $user->updateCollaboratorGithubUsernames();
             }
+            if ($user->isDirty('github_user_id')) {
+                $user->updateCollaboratorGithubUserIds();
+            }
         });
     }
 
@@ -144,6 +147,20 @@ class User extends Authenticatable
             })
             ->each(function ($collaborator) {
                 $collaborator->update(['github_username' => $this->github_username]);
+            });
+    }
+
+    public function updateCollaboratorGithubUserIds()
+    {
+        $this->collaborators
+            ->reject(function ($collaborator) {
+                return (bool) $collaborator->github_user_id;
+            })
+            ->filter(function ($collaborator) {
+                return $collaborator->github_username === $this->github_username;
+            })
+            ->each(function ($collaborator) {
+                $collaborator->update(['github_user_id' => $this->github_user_id]);
             });
     }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -34,7 +34,7 @@ class User extends Authenticatable
      * @var array
      */
     protected $fillable = [
-        'name', 'email', 'avatar', 'github_username',
+        'name', 'email', 'avatar', 'github_username', 'github_user_id',
     ];
 
     /**

--- a/app/User.php
+++ b/app/User.php
@@ -53,6 +53,9 @@ class User extends Authenticatable
             if ($user->isDirty('name')) {
                 $user->updateCollaboratorNames();
             }
+            if ($user->isDirty('github_username')) {
+                $user->updateCollaboratorGithubUsernames();
+            }
         });
     }
 
@@ -127,6 +130,20 @@ class User extends Authenticatable
             })
             ->each(function ($collaborator) {
                 $collaborator->update(['name' => $this->name]);
+            });
+    }
+
+    public function updateCollaboratorGithubUsernames()
+    {
+        $this->collaborators
+            ->reject(function ($collaborator) {
+                return ! $collaborator->github_user_id;
+            })
+            ->filter(function ($collaborator) {
+                return (int) $collaborator->github_user_id === (int) $this->github_user_id;
+            })
+            ->each(function ($collaborator) {
+                $collaborator->update(['github_username' => $this->github_username]);
             });
     }
 }

--- a/database/migrations/2020_02_04_173845_add_github_user_id_column_to_users_table.php
+++ b/database/migrations/2020_02_04_173845_add_github_user_id_column_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddGithubUserIdColumnToUsersTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->integer('github_user_id')->after('github_username')->nullable();
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('github_user_id');
+        });
+    }
+}

--- a/database/migrations/2020_02_04_180322_add_github_user_id_column_to_collaborators_table.php
+++ b/database/migrations/2020_02_04_180322_add_github_user_id_column_to_collaborators_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddGithubUserIdColumnToCollaboratorsTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('collaborators', function (Blueprint $table) {
+            $table->integer('github_user_id')->after('github_username')->nullable();
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('collaborators', function (Blueprint $table) {
+            $table->dropColumn('github_user_id');
+        });
+    }
+}

--- a/tests/Feature/UserTest.php
+++ b/tests/Feature/UserTest.php
@@ -113,4 +113,64 @@ class UserTest extends TestCase
 
         $this->assertEquals('calebdume', $collaborator->fresh()->github_username);
     }
+
+    /** @test */
+    function updating_collaborator_github_user_id_on_user_update()
+    {
+        $user = factory(User::class)->create([
+            'github_user_id' => null,
+            'github_username' => 'calebdume',
+        ]);
+        $collaborator = factory(Collaborator::class)->make([
+            'github_user_id' => null,
+            'github_username' => 'calebdume',
+        ]);
+        $user->collaborators()->save($collaborator);
+
+        $user->update(['github_user_id' => 123]);
+
+        $this->assertEquals(123, $collaborator->fresh()->github_user_id);
+    }
+
+    /** @test */
+    function collaborator_github_user_ids_are_only_updated_where_github_username_matches()
+    {
+        $user = factory(User::class)->create([
+            'github_user_id' => null,
+            'github_username' => 'calebdume',
+        ]);
+        $collaborator = factory(Collaborator::class)->make([
+            'github_user_id' => null,
+            'github_username' => 'calebdume',
+        ]);
+        $newCollaborator = factory(Collaborator::class)->make([
+            'github_user_id' => null,
+            'github_username' => 'ezrabridger',
+        ]);
+        $user->collaborators()->save($collaborator);
+        $user->collaborators()->save($newCollaborator);
+
+        $user->update(['github_user_id' => 123]);
+
+        $this->assertEquals(123, $collaborator->fresh()->github_user_id);
+        $this->assertNull($newCollaborator->fresh()->github_user_id);
+    }
+
+    /** @test */
+    function collaborator_github_user_id_is_only_updated_when_it_is_null()
+    {
+        $user = factory(User::class)->create([
+            'github_user_id' => null,
+            'github_username' => 'calebdume',
+        ]);
+        $collaborator = factory(Collaborator::class)->make([
+            'github_user_id' => 321,
+            'github_username' => 'calebdume',
+        ]);
+        $user->collaborators()->save($collaborator);
+
+        $user->update(['github_user_id' => 123]);
+
+        $this->assertEquals(321, $collaborator->fresh()->github_user_id);
+    }
 }

--- a/tests/Feature/UserTest.php
+++ b/tests/Feature/UserTest.php
@@ -53,4 +53,62 @@ class UserTest extends TestCase
         $this->assertEquals('Kanan Jarrus', $collaborator->fresh()->name);
         $this->assertEquals('Ezra Bridger', $newCollaborator->fresh()->name);
     }
+
+    /** @test */
+    function updating_collaborator_github_usernames_when_the_user_github_username_changes()
+    {
+        $user = factory(User::class)->create([
+            'github_username' => 'calebdume',
+        ]);
+        $collaborator = factory(Collaborator::class)->make([
+            'github_username' => 'calebdume',
+        ]);
+        $user->collaborators()->save($collaborator);
+
+        $user->update(['github_username' => 'kananjarrus']);
+
+        $this->assertEquals('kananjarrus', $collaborator->fresh()->github_username);
+    }
+
+    /** @test */
+    function updating_collaborator_github_usernames_only_updates_where_same_github_user_id()
+    {
+        $user = factory(User::class)->create([
+            'github_user_id' => 1,
+            'github_username' => 'calebdume',
+        ]);
+        $collaborator = factory(Collaborator::class)->make([
+            'github_user_id' => 1,
+            'github_username' => 'calebdume',
+        ]);
+        $newCollaborator = factory(Collaborator::class)->make([
+            'github_user_id' => 2,
+            'github_username' => 'ezrabridger',
+        ]);
+        $user->collaborators()->save($collaborator);
+        $user->collaborators()->save($newCollaborator);
+
+        $user->update(['github_username' => 'kananjarrus']);
+
+        $this->assertEquals('kananjarrus', $collaborator->fresh()->github_username);
+        $this->assertEquals('ezrabridger', $newCollaborator->fresh()->github_username);
+    }
+
+    /** @test */
+    function collaborator_github_usernames_are_only_updated_when_github_user_id_is_set()
+    {
+        $user = factory(User::class)->create([
+            'github_user_id' => null,
+            'github_username' => 'calebdume',
+        ]);
+        $collaborator = factory(Collaborator::class)->make([
+            'github_user_id' => null,
+            'github_username' => 'calebdume',
+        ]);
+        $user->collaborators()->save($collaborator);
+
+        $user->update(['github_username' => 'kananjarrus']);
+
+        $this->assertEquals('calebdume', $collaborator->fresh()->github_username);
+    }
 }

--- a/tests/Feature/UserTest.php
+++ b/tests/Feature/UserTest.php
@@ -58,9 +58,11 @@ class UserTest extends TestCase
     function updating_collaborator_github_usernames_when_the_user_github_username_changes()
     {
         $user = factory(User::class)->create([
+            'github_user_id' => 123,
             'github_username' => 'calebdume',
         ]);
         $collaborator = factory(Collaborator::class)->make([
+            'github_user_id' => 123,
             'github_username' => 'calebdume',
         ]);
         $user->collaborators()->save($collaborator);
@@ -74,15 +76,15 @@ class UserTest extends TestCase
     function updating_collaborator_github_usernames_only_updates_where_same_github_user_id()
     {
         $user = factory(User::class)->create([
-            'github_user_id' => 1,
+            'github_user_id' => 123,
             'github_username' => 'calebdume',
         ]);
         $collaborator = factory(Collaborator::class)->make([
-            'github_user_id' => 1,
+            'github_user_id' => 123,
             'github_username' => 'calebdume',
         ]);
         $newCollaborator = factory(Collaborator::class)->make([
-            'github_user_id' => 2,
+            'github_user_id' => 321,
             'github_username' => 'ezrabridger',
         ]);
         $user->collaborators()->save($collaborator);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -39,6 +39,7 @@ abstract class TestCase extends BaseTestCase
             'email' => $userData['email'],
             'avatar' => $userData['avatar'],
             'nickname' => $userData['github_username'],
+            'id' => $userData['github_user_id'],
         ]);
 
         $m = $this->createMock(GithubProvider::class);


### PR DESCRIPTION
This PR is a follow-up to #17 

This PR adds a `github_user_id` column to both the `users` and `collaborators` tables in order to keep the Github account details in sync between the user related collaborator rows.

## Filling the user's Github user ID
Upon successful login, if the user's `github_user_id` column is null, it will be updated with the `id` returned from Socialite.  At that time any related rows in the `collaborators` table will also be updated with the same `github_user_id` where the `github_username` is the same as the user's `github_username`.

## Updating the colaborator's Github user ID
As a result of being able to match the collaborator row by `github_user_id` we can now automatically update the collaborator's `github_username` column when it is changed on the user.  When a user's `github_username` is changed we will updated any related collaborator rows with the new `github_username` where they also match by `github_user_id`.