### PR TITLE
Fix review date

### DIFF
--- a/resources/assets/js/components/Review.vue
+++ b/resources/assets/js/components/Review.vue
@@ -85,7 +85,7 @@ export default {
         return {
             author: this.review.user,
             content: this.review.content,
-            date: moment(this.review.update_at).format('MMMM D, YYYY'),
+            date: moment(this.review.updated_at).format('MMMM D, YYYY'),
             isEditing: false,
             showReview: true,
         };


### PR DESCRIPTION
All reviews on the site currently mistakenly show that they were posted today, which is incorrect. Looks like there was a typo in the field used (`update_at` vs `updated_at`) causing moment to fall back to the current date.