### PR TITLE
Add validation for reviews and ratings

### DIFF
--- a/app/Http/Controllers/InternalApi/RatingsController.php
+++ b/app/Http/Controllers/InternalApi/RatingsController.php
@@ -14,6 +14,14 @@ class RatingsController extends Controller
 {
     public function store()
     {
+        request()->validate([
+            'package_id' => [
+                'required',
+                'exists:App\Package,id',
+            ],
+            'rating' => 'required',
+        ]);
+
         try {
             auth()->user()->ratePackage(request('package_id'), request('rating'));
         } catch (SelfAuthoredRatingException $e) {

--- a/app/Http/Controllers/InternalApi/ReviewsController.php
+++ b/app/Http/Controllers/InternalApi/ReviewsController.php
@@ -24,6 +24,14 @@ class ReviewsController extends Controller
 
     public function update()
     {
+        request()->validate([
+            'package_id' => [
+                'required',
+                'exists:App\Package,id'
+            ],
+            'review' => 'required',
+        ]);
+
         Package::findOrFail(request('package_id'))->updateReview(request('review'));
 
         return ['status' => 'success', 'message' => 'Review edited successfully'];

--- a/app/Http/Controllers/InternalApi/ReviewsController.php
+++ b/app/Http/Controllers/InternalApi/ReviewsController.php
@@ -13,6 +13,14 @@ class ReviewsController extends Controller
 {
     public function store()
     {
+        request()->validate([
+            'package_id' => [
+                'required',
+                'exists:App\Package,id',
+            ],
+            'review' => 'required',
+        ]);
+
         Package::findOrFail(request('package_id'))
             ->addReview(
                 Rating::where('rateable_id', request('package_id'))->where('user_id', auth()->id())->first()->id,
@@ -27,7 +35,7 @@ class ReviewsController extends Controller
         request()->validate([
             'package_id' => [
                 'required',
-                'exists:App\Package,id'
+                'exists:App\Package,id',
             ],
             'review' => 'required',
         ]);


### PR DESCRIPTION
This PR adds a few validation checks around reviews and ratings. There are more missing rules elsewhere but this moves the app in the right direction.